### PR TITLE
Add support for hyphens in error message paths

### DIFF
--- a/Unity.sublime-build
+++ b/Unity.sublime-build
@@ -6,7 +6,7 @@
             "/noconsolelogger",
             "/logger:${packages}\\Unity3D Build System\\SublimeLogger.dll"
         ],
-        "file_regex": "^([\\d\\w:\\\\\\.]*)\\((\\d+),(\\d+)\\)\\s*(.*)$"
+        "file_regex": "^([\\d\\w:\\\\\\.-]*)\\((\\d+),(\\d+)\\)\\s*(.*)$"
     },
     "osx": {
         "cmd": [
@@ -15,7 +15,7 @@
             "/noconsolelogger",
             "/logger:${packages}/Unity3D Build System/SublimeLogger.dll"
         ],
-        "file_regex": "^([\\d\\w:/\\.]*)\\((\\d+),(\\d+)\\)\\s*(.*)$"
+        "file_regex": "^([\\d\\w:/\\.-]*)\\((\\d+),(\\d+)\\)\\s*(.*)$"
     },
     "variants": [
         {


### PR DESCRIPTION
This fix adds support for hyphens in filesystem paths when detecting error messages in build output.

Example message that the old regex couldn't find:

```
/Users/mildmojo/are-you-kidding-me/Assets/Popup.cs(9,15)  error:CS1519  Unexpected symbol `;' in class, struct, or interface member declaration
```

:cactus:
